### PR TITLE
Implements embedded signup forms (part 3)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'devise'
 gem 'haml'
 gem 'multi_json'
 gem 'active_model_serializers'
+gem 'rack-cors', require: 'rack/cors'
 
 gem 'bundler'
 gem 'angular-rails-templates'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rack (1.6.4)
+    rack-cors (0.4.0)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.4)
@@ -209,6 +210,7 @@ DEPENDENCIES
   less-rails
   multi_json
   pry
+  rack-cors
   rails (= 4.2.4)
   rails-assets-angular!
   rails-assets-angular-growl-2!

--- a/app/assets/javascripts/autoresponder/components/common/templateManager.js
+++ b/app/assets/javascripts/autoresponder/components/common/templateManager.js
@@ -1,0 +1,20 @@
+AutoresponderApp.factory('templateManager', function() {
+  return {
+    loadTemplate:  function (template_name) {
+      var template;
+      switch (template_name) {
+        case "template_one":
+          //lets add the redirect_to for already subscribed and thank you page elements
+          template = "<form action='{{subscribe_url}}' id='embeded-subscribe-autoresponder' method='post' name='embeded_subscribe_autoresponder' novalidate='' target='_blank'>\n<label for='subscribe_email'>Email Address</label>\n<input name='subscribe_email' type='email' value=''>\n<label for='subscribe_name'>Full Name</label>\n<input name='subscribe_name_input' type='text' value=''>\n<input type='hidden' name='thank_you_page' value='{{thank_you_page}}'/>\n<input type='hidden' name='already_subscribed_page' value='{{already_subscribed_page}}'/><br>\n<input name='subscribe-submit' type='submit' value='Subscribe'>\n</form>";
+          break;
+        case "template_two":
+          template = "template_two";
+          break;
+        default:
+          template = "";
+      }
+
+      return template;
+    }
+  }
+});

--- a/app/assets/javascripts/autoresponder/components/common/utils.js
+++ b/app/assets/javascripts/autoresponder/components/common/utils.js
@@ -1,0 +1,11 @@
+AutoresponderApp.factory('Utils', function() {
+  return {
+    // if you need to get if the url includes http or https
+    httpProtocolUrlFor: function(url_params) {
+      var domain, port;
+      domain = window.location.protocol + "//" + window.location.hostname;
+      port = window.location.port ? ":" + window.location.port : "";
+      return domain + port + url_params;
+    },
+  }
+});

--- a/app/assets/javascripts/autoresponder/components/email_lists/details/signup_forms/emailSignupCtrl.js
+++ b/app/assets/javascripts/autoresponder/components/email_lists/details/signup_forms/emailSignupCtrl.js
@@ -1,0 +1,43 @@
+AutoresponderApp
+  .controller('emailListSignupFormCtrl', [
+    '$scope',
+    '$sce',
+    'findCurrentEmailListInParent',
+    'Render',
+    'Utils',
+    function (
+      $scope,
+      $sce,
+      findCurrentEmailListInParent,
+      Render,
+      Utils
+    ) {
+
+      var currentList = findCurrentEmailListInParent.plain();
+      var subscribeUrl = "/api/v1/email_lists/subscribe/" + currentList.secure_key;
+      var fullSubscribeUrl = Utils.httpProtocolUrlFor(subscribeUrl);
+
+      $scope.subscribe_url = $sce.trustAsResourceUrl(fullSubscribeUrl);
+      $scope.thank_you_page = currentList.thank_you_page_url;
+      $scope.already_subscribed_page = currentList.already_subscribed_url;
+
+      $scope.availablePublish = function() {
+        return ($scope.email_list.thank_you_page_url && $scope.email_list.already_subscribed_url);
+      }
+
+      $scope.handlePublish = function() {
+        if ($scope.availablePublish()) {
+          // we are visiting a sibling called publish
+          // because we are in the sibling called '.settings'
+          $scope.$state.go('^.publish');
+        } else {
+          $scope.showNotificationRequiredFields();
+        }
+      }
+
+      $scope.showNotificationRequiredFields = function() {
+        Render.showGrowlNotification('warning', 'Before to publish the form you must select the custom urls');
+      }
+    }
+  ])
+

--- a/app/assets/javascripts/autoresponder/components/email_lists/details/signup_forms/main.html.haml
+++ b/app/assets/javascripts/autoresponder/components/email_lists/details/signup_forms/main.html.haml
@@ -1,0 +1,13 @@
+.row
+  .email-list-details.col-md-2.col-md-offset-10
+    %ul.nav-menu.text-right
+      %li{'ng-class' => "{ 'active': $state.includes('email_list.details.signup_forms.settings') }"}
+        %a{:href => "#", 'ui-sref' => 'email_list.details.signup_forms.settings'}
+          Settings
+
+      %li{'ng-class' => "{ 'active': $state.includes('email_list.details.signup_forms.publish') }"}
+        %a{:href => "", 'ng-click' => 'handlePublish()'}
+          Publish
+
+.row
+  %ui-view

--- a/app/assets/javascripts/autoresponder/components/email_lists/details/signup_forms/publish.html.haml
+++ b/app/assets/javascripts/autoresponder/components/email_lists/details/signup_forms/publish.html.haml
@@ -1,0 +1,8 @@
+.row
+
+  .col-md-12
+
+    %textarea#output.form-control{ 'replace-textarea-values'=> '',
+                                   :rows => '10',
+                                   "ng-model" => "previewer"}
+    #hidden{"ng-hide" => "true"}

--- a/app/assets/javascripts/autoresponder/components/email_lists/details/signup_forms/replaceTextAreaDirective.js
+++ b/app/assets/javascripts/autoresponder/components/email_lists/details/signup_forms/replaceTextAreaDirective.js
@@ -1,0 +1,35 @@
+AutoresponderApp
+
+   .directive(
+     'replaceTextareaValues',
+     ['$compile', 'templateManager', '$timeout',
+     function($compile, templateManager, $timeout) {
+
+     var selectedTemplate = templateManager.loadTemplate('template_one');;
+
+     return {
+       restrict: 'A',
+       templateUrl: 'autoresponder/components/email_lists/details/signup_forms/publish.html',
+       scope: true,
+       link: function($scope, elem, attrs) {
+
+         // element included in the template
+         var hiddenElem = $('#hidden');;
+         $scope.previewer = '';
+
+         function update() {
+
+           if (selectedTemplate) {
+
+             $compile(hiddenElem.html(selectedTemplate))($scope);
+
+             $timeout( function(){
+               $scope.previewer = hiddenElem.html();
+             }, 0);
+           }
+         }
+
+         $scope.$watch('template', update);
+       }
+     };
+   }])

--- a/app/assets/javascripts/autoresponder/components/email_lists/details/signup_forms/settings.html.haml
+++ b/app/assets/javascripts/autoresponder/components/email_lists/details/signup_forms/settings.html.haml
@@ -1,0 +1,27 @@
+%form.sign-up-form-settings{:name => "EmailListForm",
+                            "ng-submit" => "updateEmailList()",
+                            :novalidate => ""}
+  .row
+    .col-md-4
+
+      .form-group
+        %label{:for => "thank-you-page"} Thank you page url (*)
+        %input#thank-you-page.form-control{:type => "url",
+                                           'required' => 'required',
+                                           :placeholder => 'http://',
+                                           "ng-model" => 'email_list.thank_you_page_url'}/
+
+      .form-group
+        %label{:for => "already-subscribed"} Already subscribed page (*)
+        %input#already-subscribed.form-control{:type => "url",
+                                               'required' => 'required',
+                                               :placeholder => 'http://',
+                                               'ng-model' => 'email_list.already_subscribed_url'}/
+
+  .row
+    .col-md-6
+      %button{ type:'submit',
+               'ng-disabled' => "EmailListForm.$invalid",
+               class: 'btn btn-success'}
+        Save settings
+

--- a/app/assets/javascripts/autoresponder/components/email_lists/emailListCtrl.js
+++ b/app/assets/javascripts/autoresponder/components/email_lists/emailListCtrl.js
@@ -14,6 +14,7 @@ AutoresponderApp
       };
 
       loadEmailLists();
+
     }
   ])
 

--- a/app/assets/javascripts/autoresponder/states.js
+++ b/app/assets/javascripts/autoresponder/states.js
@@ -60,6 +60,25 @@ AutoresponderApp
           }
         })
 
+        .state("email_list.details.signup_forms", {
+          url: "/signup_forms",
+          abstract: true,
+          controller: 'emailListSignupFormCtrl',
+          templateUrl: 'autoresponder/components/email_lists/details/signup_forms/main.html',
+        })
+
+        .state("email_list.details.signup_forms.settings", {
+          url: "",
+          controller: 'emailListSignupFormCtrl',
+          templateUrl: 'autoresponder/components/email_lists/details/signup_forms/settings.html',
+        })
+
+        .state("email_list.details.signup_forms.publish", {
+          url: "/publish",
+          controller: 'emailListSignupFormCtrl',
+          templateUrl: 'autoresponder/components/email_lists/details/signup_forms/publish.html',
+        })
+
         .state("email_list.details.form", {
           url: "",
           templateUrl: 'autoresponder/components/email_lists/details/form.html',

--- a/app/models/email_list.rb
+++ b/app/models/email_list.rb
@@ -1,12 +1,13 @@
 class EmailList < ActiveRecord::Base
   belongs_to :user
+  has_many :subscribers
 
   validates_presence_of :name,
                         :user_id,
                         :default_from,
                         :default_from_name
 
-  after_save :generate_secure_key
+  after_create :generate_secure_key
 
   private
 

--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -1,0 +1,9 @@
+class Subscriber < ActiveRecord::Base
+  belongs_to :email_list
+
+  validates_presence_of :email,
+                        :email_list_id
+
+  validates_format_of :email, :with => /\A[^@]+@([^@\.]+\.)+[^@\.]+\z/
+
+end

--- a/app/views/api/v1/email_lists/add_public_subscriber.html.haml
+++ b/app/views/api/v1/email_lists/add_public_subscriber.html.haml
@@ -1,0 +1,15 @@
+!!!
+%html{:lang => "en"}
+  %head
+    %title Email Autoresponder
+  %body.preload
+    %main
+      .error-wrapper
+        .error-box
+          .error-img
+            = image_tag 'icon-warning.png'
+          .error-copy
+            %h2#error-heading
+            %p#error-text
+              = @errors
+    %span#pingdom-check

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,19 +8,16 @@ Bundler.require(*Rails.groups)
 
 module AngularRailsAutoresponder
   class Application < Rails::Application
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
-
-    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
-
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
-
-    # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.middleware.insert_before 0, "Rack::Cors", debug: true, logger: (-> { Rails.logger }) do
+      allow do
+        origins '*'
+        resource '*',
+          headers: :any,
+          methods: [:post],
+          max_age: 0
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,11 @@ Rails.application.routes.draw do
   constraints do
     namespace :api, path: '/api' do
       namespace :v1 do
-        resources :email_lists
+        resources :email_lists do
+          collection do
+            post 'subscribe/:email_uuid', to: 'email_lists#add_public_subscriber'
+          end
+        end
       end
     end
   end

--- a/db/migrate/20150928174256_create_subscribers.rb
+++ b/db/migrate/20150928174256_create_subscribers.rb
@@ -1,0 +1,11 @@
+class CreateSubscribers < ActiveRecord::Migration
+  def change
+    create_table :subscribers do |t|
+      t.string :name
+      t.string :email
+      t.integer :email_list_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150918231938) do
+ActiveRecord::Schema.define(version: 20150928174256) do
 
   create_table "email_lists", force: :cascade do |t|
     t.string   "name"
@@ -30,6 +30,14 @@ ActiveRecord::Schema.define(version: 20150918231938) do
     t.string   "already_subscribed_url"
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
+  end
+
+  create_table "subscribers", force: :cascade do |t|
+    t.string   "name"
+    t.string   "email"
+    t.integer  "email_list_id"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Sign up forms are a incredible way to build a list of subscribers for your website, so for this commits we are implementing signup forms for email lists.

- Implements signup forms for email lists
- User is able to copy html code to start adding subscriber to their lists
- Setup CORS
- Generate html code using a directive that interpolates some dynamic values